### PR TITLE
Add my name in the trained users text file

### DIFF
--- a/records/trained_users.txt
+++ b/records/trained_users.txt
@@ -10,3 +10,4 @@ Rd Yuj
 Joodith
 Avraam
 William Weston
+Clement MUGISHA


### PR DESCRIPTION
In the Learn Git the Hard Way course on Educative. Last time the readme was in binary format because I was using my local dev environment on windows. And windows changes the format of files without asking :).